### PR TITLE
feat: support kustomize-load-restrictor flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ testbin/*
 # Misc
 dist/
 .vscode/
+
+# Release artifacts
+git-kustomize-diff

--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ Usage:
   git-kustomize-diff run target_dir [flags]
 
 Flags:
-      --allow-dirty             allow dirty tree
-      --base string             base commitish (default to origin/main)
-      --debug                   debug mode
-      --exclude string          exclude regexp (default to none)
-  -h, --help                    help for run
-      --include string          include regexp (default to all)
-      --kustomize-path string   path of a kustomize binary (default to embeded)
-      --target string           target commitish (default to the current branch)
+      --allow-dirty                        allow dirty tree
+      --base string                        base commitish (default to origin/main)
+      --debug                              debug mode
+      --exclude string                     exclude regexp (default to none)
+      --git-path string                    path of a git binary (default to git)
+  -h, --help                               help for run
+      --include string                     include regexp (default to all)
+      --kustomize-load-restrictor string   kustomize load restrictor type (default to kustomizaton provider defaults)
+      --kustomize-path string              path of a kustomize binary (default to embedded)
+      --target string                      target commitish (default to the current branch)
 ```
 
 ## Contributing

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,14 +27,15 @@ import (
 )
 
 type runFlags struct {
-	base                string
-	target              string
-	includeRegexpString string
-	excludeRegexpString string
-	kustomizePath       string
-	gitPath             string
-	debug               bool
-	allowDirty          bool
+	base                    string
+	target                  string
+	includeRegexpString     string
+	excludeRegexpString     string
+	kustomizePath           string
+	kustomizeLoadRestrictor string
+	gitPath                 string
+	debug                   bool
+	allowDirty              bool
 }
 
 var runCmd = &cobra.Command{
@@ -44,12 +45,13 @@ var runCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := gitkustomizediff.RunOpts{
-			Base:          runOpts.base,
-			Target:        runOpts.target,
-			Debug:         runOpts.debug,
-			AllowDirty:    runOpts.allowDirty,
-			KustomizePath: runOpts.kustomizePath,
-			GitPath:       runOpts.gitPath,
+			Base:                    runOpts.base,
+			Target:                  runOpts.target,
+			Debug:                   runOpts.debug,
+			AllowDirty:              runOpts.allowDirty,
+			KustomizePath:           runOpts.kustomizePath,
+			KustomizeLoadRestrictor: runOpts.kustomizeLoadRestrictor,
+			GitPath:                 runOpts.gitPath,
 		}
 		if runOpts.includeRegexpString != "" {
 			includeRegexp, err := regexp.Compile(runOpts.includeRegexpString)
@@ -89,7 +91,8 @@ func init() {
 	runCmd.PersistentFlags().StringVar(&runOpts.target, "target", "", "target commitish (default to the current branch)")
 	runCmd.PersistentFlags().StringVar(&runOpts.includeRegexpString, "include", "", "include regexp (default to all)")
 	runCmd.PersistentFlags().StringVar(&runOpts.excludeRegexpString, "exclude", "", "exclude regexp (default to none)")
-	runCmd.PersistentFlags().StringVar(&runOpts.kustomizePath, "kustomize-path", "", "path of a kustomize binary (default to embeded)")
+	runCmd.PersistentFlags().StringVar(&runOpts.kustomizePath, "kustomize-path", "", "path of a kustomize binary (default to embedded)")
+	runCmd.PersistentFlags().StringVar(&runOpts.kustomizeLoadRestrictor, "kustomize-load-restrictor", "", "kustomize load restrictor type (default to kustomizaton provider defaults)")
 	runCmd.PersistentFlags().StringVar(&runOpts.gitPath, "git-path", "", "path of a git binary (default to git)")
 	runCmd.PersistentFlags().BoolVar(&runOpts.debug, "debug", false, "debug mode")
 	runCmd.PersistentFlags().BoolVar(&runOpts.allowDirty, "allow-dirty", false, "allow dirty tree")

--- a/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/base/sub1/nested/kustomization.yaml
+++ b/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/base/sub1/nested/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../pod.yaml

--- a/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/base/sub1/pod.yaml
+++ b/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/base/sub1/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sub1
+spec:
+  containers:
+  - name: sub1
+    image: nginx:latest

--- a/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/target/sub1/nested/kustomization.yaml
+++ b/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/target/sub1/nested/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../pod.yaml

--- a/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/target/sub1/pod.yaml
+++ b/pkg/gitkustomizediff/fixtures/diff-load-restrictions-none/target/sub1/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sub1
+spec:
+  containers:
+  - name: sub1-modified
+    image: nginx:latest

--- a/pkg/gitkustomizediff/run.go
+++ b/pkg/gitkustomizediff/run.go
@@ -27,14 +27,15 @@ import (
 )
 
 type RunOpts struct {
-	Base          string
-	Target        string
-	IncludeRegexp *regexp.Regexp
-	ExcludeRegexp *regexp.Regexp
-	KustomizePath string
-	GitPath       string
-	Debug         bool
-	AllowDirty    bool
+	Base                    string
+	Target                  string
+	IncludeRegexp           *regexp.Regexp
+	ExcludeRegexp           *regexp.Regexp
+	KustomizePath           string
+	KustomizeLoadRestrictor string
+	GitPath                 string
+	Debug                   bool
+	AllowDirty              bool
 }
 
 type RunResult struct {
@@ -119,9 +120,10 @@ func Run(dirPath string, opts RunOpts) (*RunResult, error) {
 	}
 
 	diffMap, err := Diff(baseGitDir.WorkDir.Dir, targetGitDir.WorkDir.Dir, DiffOpts{
-		IncludeRegexp: opts.IncludeRegexp,
-		ExcludeRegexp: opts.ExcludeRegexp,
-		KustomizePath: opts.KustomizePath,
+		IncludeRegexp:           opts.IncludeRegexp,
+		ExcludeRegexp:           opts.ExcludeRegexp,
+		KustomizePath:           opts.KustomizePath,
+		KustomizeLoadRestrictor: opts.KustomizeLoadRestrictor,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Summary of changes:
- Add support for the `--kustomize-load-restrictor` flag that lets you set the `LoadRestrictions` option when running build/diff for the given kustomization provider (embedded or external via `--kustomize-path`)
- Update the README for the new help output
- Add tests for build + diff using the new LoadRestrictions option passthrough
- Add the `git-kustomize-diff` binary to `.gitignore`