### PR TITLE
feat: Add `--fail-on-diff-error` CLI flag to return non-zero exit code on diff error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Flags:
       --base string                        base commitish (default to origin/main)
       --debug                              debug mode
       --exclude string                     exclude regexp (default to none)
+      --fail-on-kustomize-error            return non-zero status code if kustomize build fails
       --git-path string                    path of a git binary (default to git)
   -h, --help                               help for run
       --include string                     include regexp (default to all)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ $ git-kustomize-diff run
 Flags:
 
 ```
+Usage:
+  git-kustomize-diff run target_dir [flags]
+
 Flags:
       --allow-dirty                        allow dirty tree
       --base string                        base commitish (default to origin/main)

--- a/README.md
+++ b/README.md
@@ -37,15 +37,12 @@ $ git-kustomize-diff run
 Flags:
 
 ```
-Usage:
-  git-kustomize-diff run target_dir [flags]
-
 Flags:
       --allow-dirty                        allow dirty tree
       --base string                        base commitish (default to origin/main)
       --debug                              debug mode
       --exclude string                     exclude regexp (default to none)
-      --fail-on-kustomize-error            return non-zero status code if kustomize build fails
+      --fail-on-diff-error                 return non-zero status code if a diff error occurs
       --git-path string                    path of a git binary (default to git)
   -h, --help                               help for run
       --include string                     include regexp (default to all)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ type rootFlags struct {
 var RootCmd = &cobra.Command{
 	Use:           "git-kustomize-diff",
 	Short:         "git-kustomize-diff",
+	SilenceUsage:  true,
 	SilenceErrors: false,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if cmd.Use == "version" {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,7 +36,7 @@ type runFlags struct {
 	gitPath                 string
 	debug                   bool
 	allowDirty              bool
-	failOnKustomizeError    bool
+	failOnDiffError         bool
 }
 
 var runCmd = &cobra.Command{
@@ -81,10 +81,10 @@ var runCmd = &cobra.Command{
 
 		printRunResult(dir, opts, res)
 
-		if runOpts.failOnKustomizeError {
+		if runOpts.failOnDiffError {
 			for _, v := range res.DiffMap.Results {
 				if _, ok := v.(*gitkustomizediff.DiffError); ok {
-					return fmt.Errorf("kustomize build failed")
+					return fmt.Errorf("fail on diff error")
 				}
 			}
 		}
@@ -105,7 +105,7 @@ func init() {
 	runCmd.PersistentFlags().StringVar(&runOpts.gitPath, "git-path", "", "path of a git binary (default to git)")
 	runCmd.PersistentFlags().BoolVar(&runOpts.debug, "debug", false, "debug mode")
 	runCmd.PersistentFlags().BoolVar(&runOpts.allowDirty, "allow-dirty", false, "allow dirty tree")
-	runCmd.PersistentFlags().BoolVar(&runOpts.failOnKustomizeError, "fail-on-kustomize-error", false, "return non-zero status code if kustomize build fails")
+	runCmd.PersistentFlags().BoolVar(&runOpts.failOnDiffError, "fail-on-diff-error", false, "return non-zero status code if a diff error occurs")
 }
 
 func printRunResult(dirPath string, opts gitkustomizediff.RunOpts, res *gitkustomizediff.RunResult) {


### PR DESCRIPTION
ref: #2 

A new `--fail-on-diff-error` flag has been added. When enabled, if a diff error occurs (e.g., if kustomize build fails in any directory), the command will exit with a non-zero status code. This makes detecting errors in automation and CI/CD pipelines easier.

### Changes
- Added the `--fail-on-diff-error` flag to runCmd.
- Exits with a non-zero status if a diff error occurs and the flag is enabled.
- Defaults to the current behavior if the new flag is not used.